### PR TITLE
Add register file

### DIFF
--- a/register.js
+++ b/register.js
@@ -1,0 +1,1 @@
+require('./index').transform();


### PR DESCRIPTION
This allows users to add support for the cjsx extension simply by using 

```
require('node-cjsx/register') 
```

instead of having to call 

```
require('node-cjsx').transform()
```
